### PR TITLE
Use correct XDG_PICTURES_DIR even if the env var is not present

### DIFF
--- a/hyprshot
+++ b/hyprshot
@@ -175,6 +175,7 @@ CLIPBOARD=0
 DEBUG=0
 SILENT=0
 RAW=0
+[ -z "$XDG_PICTURES_DIR" ] && type xdg-user-dir &> /dev/null && XDG_PICTURES_DIR=$(xdg-user-dir PICTURES)
 FILENAME="$(date +'%Y-%m-%d-%H%M%S_hyprshot.png')"
 [ -z "$HYPRSHOT_DIR" ] && SAVEDIR=${XDG_PICTURES_DIR:=~} || SAVEDIR=${HYPRSHOT_DIR}
 


### PR DESCRIPTION
This will only work if the `xdg-user-dir` command is present on the user’s machine, though.
